### PR TITLE
Each header cell must have at least 3 dashes.

### DIFF
--- a/mdt_test.go
+++ b/mdt_test.go
@@ -95,3 +95,31 @@ next content, next content
 	// | content      | content      |
 	// | next content | next content |
 }
+
+func ExampleConvert_short() {
+	r := strings.NewReader(`
+#,A
+1,B
+`)
+	result, _ := mdt.Convert(r)
+	fmt.Printf("%s", result)
+
+	// Output:
+	// | #   | A   |
+	// | --- | --- |
+	// | 1   | B   |
+}
+
+func ExampleConvert_short_align() {
+	r := strings.NewReader(`
+#:,:A:
+1,B
+`)
+	result, _ := mdt.Convert(r)
+	fmt.Printf("%s", result)
+
+	// Output:
+	// | #   | A   |
+	// | ---:|:---:|
+	// | 1   | B   |
+}

--- a/rows.go
+++ b/rows.go
@@ -21,6 +21,9 @@ func (r rows) lengthAt(index int) int {
 			max = n
 		}
 	}
+	if max < 3 {
+		max = 3
+	}
 	return max
 }
 


### PR DESCRIPTION
```
#, headerA
1, content
```

will be converted as follows:

```
| # | headerA |
| - | ------- |
| 1 | content |
```

But above code can't convert correctly by GFM syntax.

| # | headerA |
| - | ------- |
| 1 | content |

This adds the minimum length of divRow
